### PR TITLE
including list of files to be masked

### DIFF
--- a/SharedPrefix/.gentoo/files/sci-lapack
+++ b/SharedPrefix/.gentoo/files/sci-lapack
@@ -1,0 +1,15 @@
+## mask packages superseded by science overlay
+app-admin/eselect::gentoo
+app-eselect/eselect-blas
+app-eselect/eselect-cblas
+app-eselect/eselect-lapack
+virtual/blas::gentoo
+virtual/cblas::gentoo
+virtual/lapack::gentoo
+sci-libs/gsl::gentoo
+app-doc/blas-docs::gentoo
+app-doc/lapack-docs::gentoo
+sci-libs/blas-reference::gentoo
+sci-libs/cblas-reference::gentoo
+sci-libs/lapack-reference::gentoo
+sci-libs/mkl::gentoo

--- a/SharedPrefix/sciencify.sh
+++ b/SharedPrefix/sciencify.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 EPREFIX=${1:-$HOME/gentoo/}
 


### PR DESCRIPTION
@Doeme I'd like you feedback on this before I merge. As it stands the script can't be executed because: 

```
cp: cannot stat '.gentoo/files/sci-lapack': No such file or directory
```

This fixes it. Was the `cp` line part of some smart workflow or just an omission?


Also, the script keeps going even if part of this fails. IS there a nice way to make it completely abort if any command called within aborts?
 